### PR TITLE
fix route tracing

### DIFF
--- a/dist/util/geo/snap.js
+++ b/dist/util/geo/snap.js
@@ -20,6 +20,10 @@ var _numeral = require('numeral');
 
 var _numeral2 = _interopRequireDefault(_numeral);
 
+var _simplify = require('./simplify');
+
+var _simplify2 = _interopRequireDefault(_simplify);
+
 var _lodash = require('lodash');
 
 var _lodash2 = _interopRequireDefault(_lodash);
@@ -37,7 +41,7 @@ const types = {
   bus: 'bus'
 };
 
-const encodePath = path => _lodash2.default.map(path.coordinates, i => ({
+const encodePath = path => _lodash2.default.map((0, _simplify2.default)(path, { tolerance: 0.000001 }).coordinates, i => ({
   lon: (0, _numeral2.default)(i[0].toFixed(6)).value(), // Valhalla wants 6-digit precision
   lat: (0, _numeral2.default)(i[1].toFixed(6)).value()
 }));

--- a/dist/util/geo/snap.js
+++ b/dist/util/geo/snap.js
@@ -60,7 +60,7 @@ exports.default = async ({ type, path, optional }) => {
   let out;
   try {
     const { body } = await _superagent2.default.post(pelias.hosts.trace).retry(10).type('json').set('apikey', pelias.key).agent(agent).send(q);
-    out = _polyline2.default.toGeoJSON(body.trip.legs[0].shape);
+    out = _polyline2.default.toGeoJSON(body.trip.legs[0].shape, 6);
   } catch (err) {
     if (!optional) {
       if (err.response && err.response.body && err.response.body.error) {

--- a/dist/util/geo/snap.js
+++ b/dist/util/geo/snap.js
@@ -16,17 +16,9 @@ var _quickLru2 = _interopRequireDefault(_quickLru);
 
 var _http = require('http');
 
-var _numeral = require('numeral');
+var _geojsonPrecision = require('geojson-precision');
 
-var _numeral2 = _interopRequireDefault(_numeral);
-
-var _simplify = require('./simplify');
-
-var _simplify2 = _interopRequireDefault(_simplify);
-
-var _lodash = require('lodash');
-
-var _lodash2 = _interopRequireDefault(_lodash);
+var _geojsonPrecision2 = _interopRequireDefault(_geojsonPrecision);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -41,9 +33,10 @@ const types = {
   bus: 'bus'
 };
 
-const encodePath = path => _lodash2.default.map((0, _simplify2.default)(path, { tolerance: 0.000001 }).coordinates, i => ({
-  lon: (0, _numeral2.default)(i[0].toFixed(6)).value(), // Valhalla wants 6-digit precision
-  lat: (0, _numeral2.default)(i[1].toFixed(6)).value()
+const encodePath = path => (0, _geojsonPrecision2.default)(path, 6) // Valhalla wants 6-digit precision
+.coordinates.map(i => ({
+  lon: i[0],
+  lat: i[1]
 }));
 
 exports.default = async ({ type, path, optional }) => {

--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
     "convert-units": "^2.3.4",
     "decamelize": "^2.0.0",
     "geo-tz": "^5.0.0",
+    "geojson-precision": "^1.0.0",
     "is-sea": "^0.3.1",
     "lodash": "^4.17.4",
     "moize": "^5.4.2",

--- a/src/util/geo/snap.js
+++ b/src/util/geo/snap.js
@@ -2,9 +2,7 @@ import request from 'superagent'
 import polyline from '@mapbox/polyline'
 import QuickLRU from 'quick-lru'
 import { Agent } from 'http'
-import numeral from 'numeral'
-import simplify from './simplify'
-import _ from 'lodash'
+import geoPrecision from 'geojson-precision'
 
 const { pelias } = global.__vandelay_util_config
 const lru = new QuickLRU({ maxSize: 10000 })
@@ -17,10 +15,12 @@ const types = {
   bus: 'bus'
 }
 
-const encodePath = (path) => _.map(simplify(path, { tolerance: 0.000001 }).coordinates, (i) => ({
-  lon: numeral(i[0].toFixed(6)).value(), // Valhalla wants 6-digit precision
-  lat: numeral(i[1].toFixed(6)).value()
-}))
+const encodePath = (path) => geoPrecision(path, 6) // Valhalla wants 6-digit precision
+  .coordinates
+  .map((i) => ({
+    lon: i[0],
+    lat: i[1]
+  }))
 
 
 export default async ({ type, path, optional }) => {

--- a/src/util/geo/snap.js
+++ b/src/util/geo/snap.js
@@ -3,6 +3,7 @@ import polyline from '@mapbox/polyline'
 import QuickLRU from 'quick-lru'
 import { Agent } from 'http'
 import numeral from 'numeral'
+import simplify from './simplify'
 import _ from 'lodash'
 
 const { pelias } = global.__vandelay_util_config
@@ -16,7 +17,7 @@ const types = {
   bus: 'bus'
 }
 
-const encodePath = (path) => _.map(path.coordinates, (i) => ({
+const encodePath = (path) => _.map(simplify(path, { tolerance: 0.000001 }).coordinates, (i) => ({
   lon: numeral(i[0].toFixed(6)).value(), // Valhalla wants 6-digit precision
   lat: numeral(i[1].toFixed(6)).value()
 }))

--- a/src/util/geo/snap.js
+++ b/src/util/geo/snap.js
@@ -46,7 +46,7 @@ export default async ({ type, path, optional }) => {
       .set('apikey', pelias.key)
       .agent(agent)
       .send(q)
-    out = polyline.toGeoJSON(body.trip.legs[0].shape)
+    out = polyline.toGeoJSON(body.trip.legs[0].shape, 6)
   } catch (err) {
     if (!optional) {
       if (err.response && err.response.body && err.response.body.error) {


### PR DESCRIPTION
While what we had before *should* have worked, it appears Valhalla can be a bit touchy about decimal precision and really wants everything to have 6 decimal places. I have been able to get some requests to work with 7 digits, but there isn't a lot of info on it and exactly no useful debugging information included in responses from the API.

This also uses `shape` instead of `encoded_polyline`

These changes closes #2890 on product