### PR TITLE
Fix util.geo.locate returning inaccurate results

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint src test",
     "lint:fix": "eslint src test --fix",
     "test": "mocha --require babel-register --recursive --reporter spec && npm run-script lint",
-    "test:debug": "mocha --inspect --require babel-register --recursive --reporter spec"
+    "test:debug": "mocha --inspect-brk=0.0.0.0 --require babel-register --recursive --reporter spec"
   },
   "devDependencies": {
     "babel-cli": "^6.4.0",
@@ -39,6 +39,8 @@
     "eslint-config-rackt": "^1.1.1",
     "eslint-plugin-babel": "^5.1.0",
     "eslint-plugin-mocha": "^5.0.0",
+    "express": "^4.16.4",
+    "get-port": "^5.0.0",
     "mocha": "^5.0.0",
     "rewire": "^4.0.1",
     "rimraf": "^2.5.0",

--- a/src/lib/pelias.js
+++ b/src/lib/pelias.js
@@ -4,37 +4,36 @@ import { Agent } from 'http'
 const { pelias } = global.__vandelay_util_config
 const agent = new Agent({ keepAlive: true })
 
-const makeRequest = async (opts) =>
-  request.get(opts.host)
-    .retry(10)
-    .type('json')
-    .agent(agent)
-    .set('apikey', pelias.key)
-    .query(opts.query)
+const makeRequest = async (opts) => request.get(opts.host)
+  .retry(10)
+  .type('json')
+  .agent(agent)
+  .set('apikey', pelias.key)
+  .query(opts.query)
 
-const parseResponse = (body) => {
-  const res = body.features[0]
-  return {
-    type: res.geometry.type,
-    coordinates: res.geometry.coordinates,
-    bbox: res.bbox,
-    properties: {
-      short: res.properties.name,
-      full: res.properties.label,
-      city: res.properties.locality,
-      county: res.properties.county,
-      region: res.properties.region,
-      country: res.properties.country
-    }
+const parseResponse = ([ res ]) => ({
+  type: res.geometry.type,
+  coordinates: res.geometry.coordinates,
+  bbox: res.bbox,
+  properties: {
+    short: res.properties.name,
+    full: res.properties.label,
+    city: res.properties.locality,
+    county: res.properties.county,
+    region: res.properties.region,
+    country: res.properties.country
   }
-}
+})
 
-const handleQuery = async (opts) => {
+const handleQuery = async ({ host, query, minConfidence = 0.9 }) => {
+  const { pelias } = global.__vandelay_util_config
   if (!pelias) throw new Error('Missing pelias configuration option (in geo.locate)')
   try {
-    const { body } = await makeRequest(opts)
+    const { body } = await makeRequest({ host, query })
     if (!body || !body.features || !body.features[0]) return
-    return parseResponse(body)
+    const features = body.features.filter((f) => f.properties.confidence >= minConfidence) // filter by confidence
+    if (!features[0]) return // if there are no features, confidence was too low
+    return parseResponse(features)
   } catch (err) {
     throw new Error(`${err.message || err} (in geo.locate)`)
   }

--- a/src/util/geo/intersection.js
+++ b/src/util/geo/intersection.js
@@ -12,7 +12,7 @@ const wayLru = new QuickLRU({ maxSize: 8000 })
 
 const agent = new Agent({ keepAlive: true })
 
-const locateCity = async ({ city, region, country }) => {
+const locateCity = async ({ city, region, country, minConfidence }) => {
   const query = {
     text: `${city}, ${region} ${country}`,
     size: 1
@@ -24,7 +24,8 @@ const locateCity = async ({ city, region, country }) => {
 
   const opts = {
     query,
-    host: pelias.hosts.search
+    host: pelias.hosts.search,
+    minConfidence
   }
   // not in cache, fetch it
   const out = await handleQuery(opts)

--- a/src/util/geo/locate.js
+++ b/src/util/geo/locate.js
@@ -4,7 +4,7 @@ import handleQuery from '../../lib/pelias'
 const { pelias } = global.__vandelay_util_config
 const lru = new QuickLRU({ maxSize: 10000 })
 
-export default async ({ address, city, region, country }) => {
+export default async ({ address, city, region, country, minConfidence }) => {
   if (!address) throw new Error('Missing address text (in geo.locate)')
   const query = {
     locality: city,
@@ -19,7 +19,8 @@ export default async ({ address, city, region, country }) => {
 
   const opts = {
     query,
-    host: pelias.hosts.structured
+    host: pelias.hosts.structured,
+    minConfidence
   }
 
   // not in cache, fetch it

--- a/test/bootstrapUtil.js
+++ b/test/bootstrapUtil.js
@@ -1,0 +1,48 @@
+/*eslint no-console: 0*/
+import createUtil from '../src'
+import express from 'express'
+import should from 'should'
+import getPort from 'get-port'
+
+const traceURL = '/trace_route'
+const structuredURL = '/v1/search/structured/'
+const searchURL = '/v1/search'
+const routeURL = '/route'
+
+const getPeliasConfig = (port) => ({
+  key: 'stae-1234',
+  hosts: {
+    trace: `http://localhost:${port}${traceURL}`,
+    structured: `http://localhost:${port}${structuredURL}`,
+    search: `http://localhost:${port}${searchURL}`,
+    route: `http://localhost:${port}${routeURL}`
+  }
+})
+
+/**
+ * Wrap requests to ensure API key passthrough
+ */
+const wrap = (lam) => (req, res) => {
+  const { apikey } = req.headers
+  should.exist(apikey, 'An API key is expected by this service')
+  should.equal(apikey, 'stae-1234', 'API key does not equal configured value')
+  return lam(req, res)
+}
+
+export default async (responses) => {
+  const port = await getPort()
+  const app = express()
+  if (responses) {
+    if (responses.structured) app.get(structuredURL, wrap(responses.structured))
+    if (responses.trace) console.log('TRACE NOT IMPLEMENTED!')
+    if (responses.search) console.log('SEARCH NOT IMPLEMENTED!')
+    if (responses.route) console.log('ROUTE NOT IMPLEMENTED!')
+  }
+  const server = app.listen(port)
+  Object.keys(require.cache)
+    .filter((m) => m.includes('src/util') || m.includes('src/lib'))
+    .map((m) => delete require.cache[m]) // remove from cache so they can be initialized properly
+  const util = createUtil({ pelias: getPeliasConfig(port) })
+  util.close = () => server.close()
+  return util
+}

--- a/test/fixtures/pelias-structured-401_harrison_st-syracuse-ny.json
+++ b/test/fixtures/pelias-structured-401_harrison_st-syracuse-ny.json
@@ -1,0 +1,75 @@
+{
+  "bbox": [
+    -76.146974,
+    43.044696,
+    -76.146974,
+    43.044696
+  ],
+  "features": [
+    {
+      "geometry": {
+        "coordinates": [
+          -76.146974,
+          43.044696
+        ],
+        "type": "Point"
+      },
+      "properties": {
+        "accuracy": "point",
+        "confidence": 1,
+        "continent": "North America",
+        "continent_gid": "whosonfirst:continent:102191575",
+        "country": "United States",
+        "country_a": "USA",
+        "country_gid": "whosonfirst:country:85633793",
+        "gid": "openaddresses:address:us/ny/statewide:da0a2a4739e598bd",
+        "housenumber": "401",
+        "id": "us/ny/statewide:da0a2a4739e598bd",
+        "label": "401 Harrison Street, Syracuse, NY, USA",
+        "layer": "address",
+        "localadmin": "Syracuse",
+        "localadmin_gid": "whosonfirst:localadmin:404522851",
+        "locality": "Syracuse",
+        "locality_gid": "whosonfirst:locality:85977785",
+        "match_type": "exact",
+        "name": "401 Harrison Street",
+        "postalcode": "13202",
+        "region": "New York",
+        "region_a": "NY",
+        "region_gid": "whosonfirst:region:85688543",
+        "source": "openaddresses",
+        "source_id": "us/ny/statewide:da0a2a4739e598bd",
+        "street": "Harrison Street"
+      },
+      "type": "Feature"
+    }
+  ],
+  "geocoding": {
+    "attribution": "https://stae.co",
+    "engine": {
+      "author": "Mapzen",
+      "name": "Pelias",
+      "version": "1.0"
+    },
+    "query": {
+      "lang": {
+        "defaulted": true,
+        "iso6391": "en",
+        "iso6393": "eng",
+        "name": "English"
+      },
+      "parsed_text": {
+        "city": "syracuse",
+        "number": "401",
+        "state": "new york",
+        "street": "Harrison St"
+      },
+      "private": false,
+      "querySize": 20,
+      "size": 10
+    },
+    "timestamp": 1555110975486,
+    "version": "0.2"
+  },
+  "type": "FeatureCollection"
+}

--- a/test/fixtures/pelias-structured-700_south_av-syracuse-ny-not_real_addr.json
+++ b/test/fixtures/pelias-structured-700_south_av-syracuse-ny-not_real_addr.json
@@ -1,0 +1,158 @@
+{
+  "geocoding" : {
+    "timestamp" : 1555110944871,
+    "attribution" : "https://stae.co",
+    "engine" : {
+      "author" : "Mapzen",
+      "name" : "Pelias",
+      "version" : "1.0"
+    },
+    "query" : {
+      "private" : false,
+      "parsed_text" : {
+        "number" : "700",
+        "street" : "SOUTH AV",
+        "city" : "syracuse",
+        "state" : "new york"
+      },
+      "size" : 10,
+      "lang" : {
+        "defaulted" : true,
+        "iso6391" : "en",
+        "iso6393" : "eng",
+        "name" : "English"
+      },
+      "querySize" : 20
+    },
+    "version" : "0.2"
+  },
+  "type" : "FeatureCollection",
+  "features" : [
+    {
+      "properties" : {
+        "localadmin" : "Syracuse",
+        "country_a" : "USA",
+        "country" : "United States",
+        "region_a" : "NY",
+        "region_gid" : "whosonfirst:region:85688543",
+        "gid" : "whosonfirst:locality:85977785",
+        "locality" : "Syracuse",
+        "match_type" : "fallback",
+        "label" : "Syracuse, NY, USA",
+        "locality_gid" : "whosonfirst:locality:85977785",
+        "continent" : "North America",
+        "localadmin_gid" : "whosonfirst:localadmin:404522851",
+        "name" : "Syracuse",
+        "continent_gid" : "whosonfirst:continent:102191575",
+        "layer" : "locality",
+        "source" : "whosonfirst",
+        "country_gid" : "whosonfirst:country:85633793",
+        "region" : "New York",
+        "id" : "85977785",
+        "source_id" : "85977785",
+        "accuracy" : "centroid",
+        "confidence" : 0.6
+      },
+      "bbox" : [
+        -76.204476,
+        42.984366,
+        -76.074084,
+        43.086102
+      ],
+      "geometry" : {
+        "coordinates" : [
+          -76.148211,
+          43.043536
+        ],
+        "type" : "Point"
+      },
+      "type" : "Feature"
+    },
+    {
+      "properties" : {
+        "match_type" : "fallback",
+        "continent" : "North America",
+        "label" : "North Syracuse, NY, USA",
+        "locality_gid" : "whosonfirst:locality:85977791",
+        "localadmin_gid" : "whosonfirst:localadmin:404522823",
+        "continent_gid" : "whosonfirst:continent:102191575",
+        "name" : "North Syracuse",
+        "source" : "whosonfirst",
+        "country_gid" : "whosonfirst:country:85633793",
+        "layer" : "locality",
+        "region" : "New York",
+        "id" : "85977791",
+        "source_id" : "85977791",
+        "accuracy" : "centroid",
+        "confidence" : 0.6,
+        "localadmin" : "Clay",
+        "country_a" : "USA",
+        "country" : "United States",
+        "region_a" : "NY",
+        "region_gid" : "whosonfirst:region:85688543",
+        "gid" : "whosonfirst:locality:85977791",
+        "locality" : "North Syracuse"
+      },
+      "type" : "Feature",
+      "bbox" : [
+        -76.148741,
+        43.122336,
+        -76.111514,
+        43.14506
+      ],
+      "geometry" : {
+        "type" : "Point",
+        "coordinates" : [
+          -76.130567,
+          43.132552
+        ]
+      }
+    },
+    {
+      "properties" : {
+        "region" : "New York",
+        "id" : "85977799",
+        "layer" : "locality",
+        "country_gid" : "whosonfirst:country:85633793",
+        "source" : "whosonfirst",
+        "name" : "East Syracuse",
+        "continent_gid" : "whosonfirst:continent:102191575",
+        "localadmin_gid" : "whosonfirst:localadmin:404521501",
+        "confidence" : 0.6,
+        "accuracy" : "centroid",
+        "source_id" : "85977799",
+        "match_type" : "fallback",
+        "locality_gid" : "whosonfirst:locality:85977799",
+        "label" : "East Syracuse, NY, USA",
+        "continent" : "North America",
+        "region_a" : "NY",
+        "country" : "United States",
+        "locality" : "East Syracuse",
+        "gid" : "whosonfirst:locality:85977799",
+        "region_gid" : "whosonfirst:region:85688543",
+        "localadmin" : "De Witt",
+        "country_a" : "USA"
+      },
+      "type" : "Feature",
+      "bbox" : [
+        -76.090354,
+        43.05552,
+        -76.051041,
+        43.071139
+      ],
+      "geometry" : {
+        "coordinates" : [
+          -76.069699,
+          43.063181
+        ],
+        "type" : "Point"
+      }
+    }
+  ],
+  "bbox" : [
+    -76.204476,
+    42.984366,
+    -76.051041,
+    43.14506
+  ]
+}

--- a/test/geo/isSea.js
+++ b/test/geo/isSea.js
@@ -4,7 +4,8 @@ import createUtil from '../../src/util'
 
 const util = createUtil()
 
-describe('geo#isSea', () => {
+describe('geo#isSea', function () {
+  this.timeout(4000)
   it('should exist', async () => {
     should.exist(util.geo.isSea)
     should.equal(typeof util.geo.isSea, 'function')

--- a/test/geo/locate.js
+++ b/test/geo/locate.js
@@ -1,11 +1,65 @@
 /*eslint no-console: 0*/
 import should from 'should'
+import bootstrapUtil from '../bootstrapUtil'
+import southAveFakeAddr from '../fixtures/pelias-structured-700_south_av-syracuse-ny-not_real_addr.json'
+import harrisonStRealAddr from '../fixtures/pelias-structured-401_harrison_st-syracuse-ny.json'
 
-const locate = require('../../src/util/geo/locate.js')
+let util
 
 describe('geo#locate', function () {
+  afterEach('cleanup util', () => util && util.close())
   it('should exist', async () => {
-    should.exist(locate)
-    should.equal(typeof locate, 'function')
+    const util = await bootstrapUtil()
+    should.exist(util.geo.locate)
+    should.equal(typeof util.geo.locate, 'function')
+  })
+  it('invalid address should return no results', async () => {
+    util = await bootstrapUtil({
+      structured: (req, res) => { // provide response for structured query
+        should.deepEqual(req.query, {
+          address: '700 SOUTH AV',
+          locality: 'syracuse',
+          region: 'new york'
+        }, 'Request should generate proper query for input values')
+        res.json(southAveFakeAddr)
+      }
+    })
+    const loc = await util.geo.locate({
+      address: '700 SOUTH AV',
+      city: 'syracuse',
+      region: 'new york'
+    })
+    should.not.exist(loc, 'util.geo.locate should return null for an invalid address')
+  })
+  it('valid address should return valid results', async () => {
+    util = await bootstrapUtil({
+      structured: (req, res) => { // provide response for structured query
+        should.deepEqual(req.query, {
+          address: '401 Harrison St',
+          locality: 'syracuse',
+          region: 'new york'
+        }, 'Request should generate proper query for input values')
+        res.json(harrisonStRealAddr) //lazy, I know, but it works
+      }
+    })
+    const loc = await util.geo.locate({
+      address: '401 Harrison St',
+      city: 'syracuse',
+      region: 'new york'
+    })
+    should.deepEqual(loc, {
+      type: 'Point',
+      coordinates: [ -76.146974, 43.044696 ],
+      bbox: undefined,
+      properties: {
+        short: '401 Harrison Street',
+        full: '401 Harrison Street, Syracuse, NY, USA',
+        city: 'Syracuse',
+        county: undefined,
+        region: 'New York',
+        country: 'United States'
+      }
+    })
+    util.close()
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,4 @@
 /*eslint no-console: 0*/
-
 import should from 'should'
 import util from '../src/util'
 


### PR DESCRIPTION
- Introduced test harness for 3rd party services
  - can be run multiple times simultaneously as it cleans up after
  itself
  - provides assertions to ensure services are always called with the
  provided API key
  - provides ability to write own functions to assert data input or
  provide custom result
- Introduced util.geo.locate test for known real address
- Introduced util.geo.locate test for nonexistent address which asserts
that the response should be null