### PR TITLE
feat: querying pelias with postalcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ util.geo.intersection({
   country: 'USA'
 })
 
-#### util.geo.locate({ address, city, region, country })
+#### util.geo.locate({ address, city, region, postalCode, country })
 #### util.geo.search({ text })
 #### util.geo.snap({ type, path, optional })
 #### util.geo.navigate({ type, start, end, optional })

--- a/src/lib/pelias.js
+++ b/src/lib/pelias.js
@@ -21,6 +21,7 @@ const parseResponse = ([ res ]) => ({
     city: res.properties.locality,
     county: res.properties.county,
     region: res.properties.region,
+    postalCode: res.properties.postalcode,
     country: res.properties.country
   }
 })

--- a/src/util/geo/locate.js
+++ b/src/util/geo/locate.js
@@ -4,10 +4,11 @@ import handleQuery from '../../lib/pelias'
 const { pelias } = global.__vandelay_util_config
 const lru = new QuickLRU({ maxSize: 10000 })
 
-export default async ({ address, city, region, country, minConfidence }) => {
+export default async ({ address, city, region, postalCode, country, minConfidence }) => {
   if (!address) throw new Error('Missing address text (in geo.locate)')
   const query = {
     locality: city,
+    postalcode: postalCode,
     region,
     country,
     address

--- a/test/geo/locate.js
+++ b/test/geo/locate.js
@@ -37,16 +37,22 @@ describe('geo#locate', function () {
         should.deepEqual(req.query, {
           address: '401 Harrison St',
           locality: 'syracuse',
-          region: 'new york'
+          region: 'new york',
+          postalcode: '13202',
+          country: 'United States'
         }, 'Request should generate proper query for input values')
         res.json(harrisonStRealAddr) //lazy, I know, but it works
       }
     })
+
     const loc = await util.geo.locate({
       address: '401 Harrison St',
       city: 'syracuse',
-      region: 'new york'
+      region: 'new york',
+      postalCode: '13202',
+      country: 'United States'
     })
+
     should.deepEqual(loc, {
       type: 'Point',
       coordinates: [ -76.146974, 43.044696 ],
@@ -55,6 +61,7 @@ describe('geo#locate', function () {
         short: '401 Harrison Street',
         full: '401 Harrison Street, Syracuse, NY, USA',
         city: 'Syracuse',
+        postalCode: '13202',
         county: undefined,
         region: 'New York',
         country: 'United States'


### PR DESCRIPTION
I've found a good amount of results will not have a city, but do have a postalcode. This allows me to ensure the match coming back is valid since the postalcode matches. Otherwise I will often get back results elsewhere in the state which are hard to verify if they are correct. 