### PR TITLE
Prevent turf from blowing up on certain coordinates

### DIFF
--- a/dist/util/geo/simplify.js
+++ b/dist/util/geo/simplify.js
@@ -24,7 +24,8 @@ exports.default = (geometry, { tolerance = 0.00001 } = {}) => {
   if (type === 'LineString' && coordinates.length === 2 && (0, _lodash.isEqual)(coordinates[0], coordinates[1])) {
     throw new Error('Invalid LineString! Only two coordinates that are identical.');
   }
-  const res = (0, _turf.simplify)((0, _turf.cleanCoords)((0, _turf.truncate)(geometry, { precision: 6, coordinates: 3 })), { tolerance });
+  const res = (0, _turf.simplify)((0, _turf.truncate)(geometry, { precision: 6, coordinates: 3 }), { tolerance });
+
   return Object.assign({
     type
   }, rest, {

--- a/src/util/geo/simplify.js
+++ b/src/util/geo/simplify.js
@@ -1,4 +1,4 @@
-import { simplify, truncate, cleanCoords } from '@turf/turf'
+import { simplify, truncate } from '@turf/turf'
 import { isEqual } from 'lodash'
 
 // 1 = 69 miles
@@ -16,9 +16,8 @@ export default (geometry, { tolerance=0.00001 }={}) => {
   if (type === 'LineString' && coordinates.length === 2 && isEqual(coordinates[0], coordinates[1])) {
     throw new Error('Invalid LineString! Only two coordinates that are identical.')
   }
-  const res = simplify(
-    cleanCoords(truncate(geometry, { precision: 6, coordinates: 3 }))
-    , { tolerance })
+  const res = simplify(truncate(geometry, { precision: 6, coordinates: 3 }), { tolerance })
+
   return {
     type,
     ...rest,


### PR DESCRIPTION
Turf already runs cleanCoords as part of simplify and it seems passing in already cleaned coordinates to cleanCoords causes it to blow up on certain coordinates. I think these coordinates are still probably not valid, but I would rather special case before or after running simplify rather than have turf blow up. 

`TypeError: Cannot read property '0' of undefined
    at /Users/brookemckim/Workspace/sales-services-scripts/mds/node_modules/@turf/turf/turf.js:6709:25
    at Array.map (<anonymous>)
    at simplifyLine (/Users/brookemckim/Workspace/sales-services-scripts/mds/node_modules/@turf/turf/turf.js:6708:35)
    at simplifyGeom (/Users/brookemckim/Workspace/sales-services-scripts/mds/node_modules/@turf/turf/turf.js:6679:38)
    at /Users/brookemckim/Workspace/sales-services-scripts/mds/node_modules/@turf/turf/turf.js:6653:9
    at geomEach (/Users/brookemckim/Workspace/sales-services-scripts/mds/node_modules/@turf/turf/turf.js:1275:17)`